### PR TITLE
Update sorting after altering ItemsSource

### DIFF
--- a/DataGridSample/DataGridSample.Droid/DataGridSample.Droid.csproj
+++ b/DataGridSample/DataGridSample.Droid/DataGridSample.Droid.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />

--- a/DataGridSample/DataGridSample/ViewModels/MainViewModel.cs
+++ b/DataGridSample/DataGridSample/ViewModels/MainViewModel.cs
@@ -1,9 +1,7 @@
 ﻿using DataGridSample.Models;
-using System;
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Xamarin.Forms;
@@ -14,16 +12,26 @@ namespace DataGridSample.ViewModels
 	{
 
 		#region fields
-		private List<Team> teams;
+		private ObservableCollection<Team> teams;
 		private Team selectedItem;
 		private bool isRefreshing;
 		#endregion
 
 		#region Properties
-		public List<Team> Teams
+		public ObservableCollection<Team> Teams
 		{
 			get { return teams; }
-			set { teams = value; OnPropertyChanged(nameof(Teams)); }
+			set
+			{
+				teams = value;
+				OnPropertyChanged(nameof(Teams));
+				OnPropertyChanged(nameof(Count));
+			}
+		}
+
+		public int Count
+		{
+			get { return Teams.Count; }
 		}
 
 		public Team SelectedTeam
@@ -43,12 +51,18 @@ namespace DataGridSample.ViewModels
 		}
 
 		public ICommand RefreshCommand { get; set; }
+		public ICommand AddCommand { get; set; }
+		public ICommand ReplaceCommand { get; set; }
+		public ICommand RemoveCommand { get; set; }
 		#endregion
 
 		public MainViewModel()
 		{
-			Teams = Utils.DummyDataProvider.GetTeams();
+			Teams = new ObservableCollection<Team>(Utils.DummyDataProvider.GetTeams());
 			RefreshCommand = new Command(CmdRefresh);
+			AddCommand = new Command(CmdAdd);
+			ReplaceCommand = new Command(ReplaceAdd);
+			RemoveCommand = new Command(RemoveAdd);
 		}
 
 		private async void CmdRefresh()
@@ -56,6 +70,47 @@ namespace DataGridSample.ViewModels
 			IsRefreshing = true;
 			// wait 3 secs for demo
 			await Task.Delay(3000);
+			IsRefreshing = false;
+		}
+
+		private void CmdAdd()
+		{
+			IsRefreshing = true;
+
+			foreach (Team team in Utils.DummyDataProvider.GetTeams())
+			{
+				Teams.Add(team);
+			}
+
+			OnPropertyChanged(nameof(Count));
+			IsRefreshing = false;
+		}
+
+		private void ReplaceAdd()
+		{
+			IsRefreshing = true;
+
+			var t = Teams.ToList();
+			t.AddRange(Utils.DummyDataProvider.GetTeams());
+			Teams = new ObservableCollection<Team>(t);
+
+			OnPropertyChanged(nameof(Count));
+			IsRefreshing = false;
+		}
+
+		private void RemoveAdd()
+		{
+			IsRefreshing = true;
+
+			var even = false;
+			foreach (Team team in Teams.ToList())
+			{
+				if (even)
+					Teams.Remove(team);
+				even = !even;
+			}
+
+			OnPropertyChanged(nameof(Count));
 			IsRefreshing = false;
 		}
 

--- a/DataGridSample/DataGridSample/Views/MainPage.xaml
+++ b/DataGridSample/DataGridSample/Views/MainPage.xaml
@@ -1,60 +1,101 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage x:Class="DataGridSample.MainPage"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="DataGridSample.MainPage"
-             Title="DataGrid Test"
-             xmlns:dg="clr-namespace:Xamarin.Forms.DataGrid;assembly=Xamarin.Forms.DataGrid"
              xmlns:conv="clr-namespace:DataGridSample.Views.Converters;assembly=DataGridSample"
-             >
-  <ContentView BackgroundColor="White" Padding="20">
-
-
-    <dg:DataGrid ItemsSource="{Binding Teams}" SelectionEnabled="True" SelectedItem="{Binding SelectedTeam}"
-                 RowHeight="70" HeaderHeight="50" BorderColor="#CCCCCC" HeaderBackground="#E0E6F8"
-                 PullToRefreshCommand="{Binding RefreshCommand}" IsRefreshing="{Binding IsRefreshing}">
-      <dg:DataGrid.HeaderFontSize>
-        <OnIdiom  x:TypeArguments="x:Double">
-          <OnIdiom.Tablet>15</OnIdiom.Tablet>
-          <OnIdiom.Phone>12</OnIdiom.Phone>
-        </OnIdiom>
-      </dg:DataGrid.HeaderFontSize>
-      <dg:DataGrid.Columns>
-        <dg:DataGridColumn Title="Logo" PropertyName="Logo" Width="100" SortingEnabled="False">
-          <dg:DataGridColumn.CellTemplate>
-            <DataTemplate>
-              <Image Source="{Binding Logo}" HorizontalOptions="Center" VerticalOptions="Center" Aspect="AspectFit" HeightRequest="60" />
-            </DataTemplate>
-          </dg:DataGridColumn.CellTemplate>
-        </dg:DataGridColumn>
-        <dg:DataGridColumn Title="Team" PropertyName="Name" Width="2*"/>
-        <dg:DataGridColumn Title="Win" PropertyName="Win" Width="0.95*"/>
-        <dg:DataGridColumn Title="Loose" PropertyName="Loose"  Width="1*"/>
-        <dg:DataGridColumn Title="Home" PropertyName="Home"/>
-        <dg:DataGridColumn Title="Percentage" PropertyName="Percentage" StringFormat="{}{0:0.00}" />
-        <dg:DataGridColumn Title="Streak" PropertyName="Streak" Width="0.7*">
-          <dg:DataGridColumn.CellTemplate>
-            <DataTemplate>
-              <ContentView HorizontalOptions="Fill" VerticalOptions="Fill"
-                           BackgroundColor="{Binding Streak,Converter={StaticResource StreakToColorConverter}}">
-                <Label Text="{Binding Streak}" HorizontalOptions="Center" VerticalOptions="Center" TextColor="Black"/>
-              </ContentView>
-            </DataTemplate>
-          </dg:DataGridColumn.CellTemplate>
-        </dg:DataGridColumn>
-      </dg:DataGrid.Columns>
-      <dg:DataGrid.RowsBackgroundColorPalette>
-        <dg:PaletteCollection>
-          <Color>#F2F2F2</Color>
-          <Color>#FFFFFF</Color>
-        </dg:PaletteCollection>
-      </dg:DataGrid.RowsBackgroundColorPalette>
-      <dg:DataGrid.Resources>
-        <ResourceDictionary>
-          <conv:StreakToColorConverter x:Key="StreakToColorConverter"/>
-        </ResourceDictionary>
-      </dg:DataGrid.Resources>
-    </dg:DataGrid>
-  </ContentView>
+             xmlns:dg="clr-namespace:Xamarin.Forms.DataGrid;assembly=Xamarin.Forms.DataGrid"
+             Title="DataGrid Test">
+	<ContentView BackgroundColor="White" Padding="20">
+		<StackLayout Orientation="Vertical">
+			<StackLayout Orientation="Horizontal">
+				<Label Text="{Binding Count}"
+				       TextColor="Black"
+				       VerticalTextAlignment="Center" />
+				<Button x:Name="Add"
+				        Command="{Binding AddCommand}"
+				        Text="Add items" />
+				<Button x:Name="Replace"
+				        Command="{Binding ReplaceCommand}"
+				        Text="Replace items" />
+				<Button x:Name="Remove"
+				        Command="{Binding RemoveCommand}"
+				        Text="Remove items" />
+			</StackLayout>
+			<dg:DataGrid BorderColor="#CCCCCC"
+			             HeaderBackground="#E0E6F8"
+			             HeaderHeight="50"
+			             IsRefreshing="{Binding IsRefreshing}"
+			             ItemsSource="{Binding Teams}"
+			             PullToRefreshCommand="{Binding RefreshCommand}"
+			             RowHeight="70"
+			             SelectedItem="{Binding SelectedTeam}"
+			             SelectionEnabled="True">
+				<dg:DataGrid.HeaderFontSize>
+					<OnIdiom x:TypeArguments="x:Double">
+						<OnIdiom.Tablet>15</OnIdiom.Tablet>
+						<OnIdiom.Phone>12</OnIdiom.Phone>
+					</OnIdiom>
+				</dg:DataGrid.HeaderFontSize>
+				<dg:DataGrid.Columns>
+					<dg:DataGridColumn Title="Logo"
+					                   Width="100"
+					                   PropertyName="Logo"
+					                   SortingEnabled="False">
+						<dg:DataGridColumn.CellTemplate>
+							<DataTemplate>
+								<Image Aspect="AspectFit"
+								       HeightRequest="60"
+								       HorizontalOptions="Center"
+								       Source="{Binding Logo}"
+								       VerticalOptions="Center" />
+							</DataTemplate>
+						</dg:DataGridColumn.CellTemplate>
+					</dg:DataGridColumn>
+					<dg:DataGridColumn Title="Team"
+					                   Width="2*"
+					                   PropertyName="Name" />
+					<dg:DataGridColumn Title="Win"
+					                   Width="0.95*"
+					                   PropertyName="Win" />
+					<dg:DataGridColumn Title="Loose"
+					                   Width="1*"
+					                   PropertyName="Loose" />
+					<dg:DataGridColumn Title="Home" PropertyName="Home" />
+					<dg:DataGridColumn Title="Percentage"
+					                   PropertyName="Percentage"
+					                   StringFormat="{}{0:0.00}" />
+					<dg:DataGridColumn Title="Streak"
+					                   Width="0.7*"
+					                   PropertyName="Streak">
+						<dg:DataGridColumn.CellTemplate>
+							<DataTemplate>
+								<ContentView BackgroundColor="{Binding Streak,
+								                                       Converter={StaticResource StreakToColorConverter}}"
+								             HorizontalOptions="Fill"
+								             VerticalOptions="Fill">
+									<Label HorizontalOptions="Center"
+									       Text="{Binding Streak}"
+									       TextColor="Black"
+									       VerticalOptions="Center" />
+								</ContentView>
+							</DataTemplate>
+						</dg:DataGridColumn.CellTemplate>
+					</dg:DataGridColumn>
+				</dg:DataGrid.Columns>
+				<dg:DataGrid.RowsBackgroundColorPalette>
+					<dg:PaletteCollection>
+						<Color>#F2F2F2</Color>
+						<Color>#FFFFFF</Color>
+					</dg:PaletteCollection>
+				</dg:DataGrid.RowsBackgroundColorPalette>
+				<dg:DataGrid.Resources>
+					<ResourceDictionary>
+						<conv:StreakToColorConverter x:Key="StreakToColorConverter" />
+					</ResourceDictionary>
+				</dg:DataGrid.Resources>
+			</dg:DataGrid>
+		</StackLayout>
+	</ContentView>
 </ContentPage>
 
 


### PR DESCRIPTION
Fixes #10 

Commit https://github.com/akgulebubekir/Xamarin.Forms.DataGrid/commit/54f6d8358793244a8b6f2fa24e992ef8654af3c0 contains the actual fix for issue #10. 
* When using an `List<t>` only replacing `ItemsSource` will update any sorting. 
* When using any collection implementing the `INotifyCollectionChanged` interface (like `ObservableCollection<t>`) will also apply the sorting after altering the original collection. You might want to promote that.

Because there's only one view and no tests, commit https://github.com/akgulebubekir/Xamarin.Forms.DataGrid/commit/b2ac5c4abb806da8d186fe31eb2ca5bd777936c9 contains code to test the bug fix by adding/replacing/removing items from the collection. I'm happy to revert this commit if you want the original view restored.
