### PR TITLE
Support ViewCell.View in DataGridViewCell

### DIFF
--- a/DataGridSample/DataGridSample/DataGridSample.csproj
+++ b/DataGridSample/DataGridSample/DataGridSample.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="App.cs" />
+    <Compile Include="Models\ChartTable.cs" />
     <Compile Include="Views\MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/DataGridSample/DataGridSample/Models/ChartTable.cs
+++ b/DataGridSample/DataGridSample/Models/ChartTable.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace DataGridSample.Models
+{
+    [DebuggerDisplay("ChartTable: Rows={this.Rows.Length}, Columns={this.Header.Columns.Length}")]
+    public class ChartTable
+    {
+        public ChartTable()
+        {
+            this.Header = null;
+        }
+
+        public ChartTableRow Header { get; set; }
+
+        public ChartTableRow[] Rows { get; set; }
+    }
+
+    [DebuggerDisplay("ChartTableRow: Columns={this.Columns.Length}")]
+    public class ChartTableRow
+    {
+        public ChartTableRow()
+        {
+            this.Columns = new ChartTableColumn[] { };
+        }
+
+        public ChartTableColumn[] Columns { get; set; }
+    }
+
+    [DebuggerDisplay("ChartTableColumn: Value={this.Value}")]
+    public class ChartTableColumn
+    {
+        public object Value { get; set; }
+    }
+}

--- a/DataGridSample/DataGridSample/Utils/DummyDataProvider.cs
+++ b/DataGridSample/DataGridSample/Utils/DummyDataProvider.cs
@@ -11,20 +11,37 @@ using DataGridSample.Models;
 
 namespace DataGridSample.Utils
 {
-	static class DummyDataProvider
-	{
-		public static List<Team> GetTeams()
-		{
-			var assembly = typeof(DummyDataProvider).GetTypeInfo().Assembly;
-			Stream stream = assembly.GetManifestResourceStream("DataGridSample.teams.json");
-			string json = string.Empty;
+    static class DummyDataProvider
+    {
+        public static List<Team> GetTeams()
+        {
+            var assembly = typeof(DummyDataProvider).GetTypeInfo().Assembly;
+            Stream stream = assembly.GetManifestResourceStream("DataGridSample.teams.json");
+            string json = string.Empty;
 
-			using (var reader = new StreamReader(stream))
-			{
-				json = reader.ReadToEnd();
-			}
+            using (var reader = new StreamReader(stream))
+            {
+                json = reader.ReadToEnd();
+            }
 
-			return JsonConvert.DeserializeObject<List<Team>>(json);
-		}
-	}
+            return JsonConvert.DeserializeObject<List<Team>>(json);
+        }
+
+        public static ChartTable GetChartTable()
+        {
+            var chartTable = new ChartTable();
+            chartTable.Header = new ChartTableRow
+            {
+                Columns = new []{ new ChartTableColumn{Value="Header_Col0"}, new ChartTableColumn { Value = "Header_Col1" }}
+            };
+            chartTable.Rows = new []
+            {
+                new ChartTableRow{ Columns = new []{ new ChartTableColumn{Value= "Row0_Col0" }, new ChartTableColumn { Value = "Row0_Col1" } }},
+                new ChartTableRow{ Columns = new []{ new ChartTableColumn{Value= "Row1_Col0" }, new ChartTableColumn { Value = "Row1_Col1" } }},
+                new ChartTableRow{ Columns = new []{ new ChartTableColumn{Value= "Row2_Col0" }, new ChartTableColumn { Value = "Row2_Col1" } }},
+            };
+
+            return chartTable;
+        }
+    }
 }

--- a/DataGridSample/DataGridSample/ViewModels/MainViewModel.cs
+++ b/DataGridSample/DataGridSample/ViewModels/MainViewModel.cs
@@ -17,13 +17,34 @@ namespace DataGridSample.ViewModels
 		private List<Team> teams;
 		private Team selectedItem;
 		private bool isRefreshing;
-		#endregion
+	    private ChartTable chartTable;
+	    private ChartTableRow selectedRow;
 
-		#region Properties
-		public List<Team> Teams
+	    #endregion
+
+        #region Properties
+
+	    public ChartTable ChartTable
+	    {
+	        get { return chartTable; }
+	        set { chartTable = value; OnPropertyChanged(nameof(ChartTable)); }
+	    }
+
+        public List<Team> Teams
 		{
 			get { return teams; }
-			set { teams = value; OnPropertyChanged(nameof(Teams)); }
+			set { teams = value;
+                OnPropertyChanged(nameof(Teams)); }
+		}
+
+		public ChartTableRow SelectedRow
+        {
+			get { return selectedRow; }
+			set
+			{
+			    selectedRow = value;
+			    OnPropertyChanged(nameof(SelectedRow));
+            }
 		}
 
 		public Team SelectedTeam
@@ -48,7 +69,8 @@ namespace DataGridSample.ViewModels
 		public MainViewModel()
 		{
 			Teams = Utils.DummyDataProvider.GetTeams();
-			RefreshCommand = new Command(CmdRefresh);
+		    ChartTable = Utils.DummyDataProvider.GetChartTable();
+            RefreshCommand = new Command(CmdRefresh);
 		}
 
 		private async void CmdRefresh()

--- a/DataGridSample/DataGridSample/Views/MainPage.xaml
+++ b/DataGridSample/DataGridSample/Views/MainPage.xaml
@@ -8,60 +8,85 @@
              >
 	<ContentView BackgroundColor="White" Padding="20">
 
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-		<dg:DataGrid ItemsSource="{Binding Teams}" SelectionEnabled="True" SelectedItem="{Binding SelectedTeam}"
+            <dg:DataGrid Grid.Row="0" ItemsSource="{Binding Teams}" SelectionEnabled="True" SelectedItem="{Binding SelectedTeam}"
 						 RowHeight="70" HeaderHeight="50" BorderColor="#CCCCCC" HeaderBackground="#E0E6F8"
 						 PullToRefreshCommand="{Binding RefreshCommand}" IsRefreshing="{Binding IsRefreshing}"
 						 ActiveRowColor="#8899AA">
-			<dg:DataGrid.HeaderFontSize>
-				<OnIdiom  x:TypeArguments="x:Double">
-					<OnIdiom.Tablet>15</OnIdiom.Tablet>
-					<OnIdiom.Phone>12</OnIdiom.Phone>
-				</OnIdiom>
-			</dg:DataGrid.HeaderFontSize>
-			<dg:DataGrid.Columns>
-				<dg:DataGridColumn Title="Logo" PropertyName="Logo" Width="100" SortingEnabled="False">
-					<dg:DataGridColumn.CellTemplate>
-						<DataTemplate>
-							<Image Source="{Binding}" HorizontalOptions="Center" VerticalOptions="Center" Aspect="AspectFit" HeightRequest="60" />
-						</DataTemplate>
-					</dg:DataGridColumn.CellTemplate>
-				</dg:DataGridColumn>
-				<dg:DataGridColumn Title="Team" PropertyName="Name" Width="2*"/>
-				<dg:DataGridColumn Title="Win" PropertyName="Win" Width="0.95*"/>
-				<dg:DataGridColumn Title="Loose" PropertyName="Loose"  Width="1*"/>
-				<dg:DataGridColumn PropertyName="Home">
-					<dg:DataGridColumn.FormattedTitle>
-						<FormattedString>
-							<Span Text="Home" ForegroundColor="Black" FontSize="13" FontAttributes="Bold"/>
-							<Span Text=" (win-loose)" ForegroundColor="#333333" FontSize="11" />
-						</FormattedString>
-					</dg:DataGridColumn.FormattedTitle>
-				</dg:DataGridColumn>
-				<dg:DataGridColumn Title="Percentage" PropertyName="Percentage" StringFormat="{}{0:0.00}" />
-				<dg:DataGridColumn Title="Streak" PropertyName="Streak" Width="0.7*">
-					<dg:DataGridColumn.CellTemplate>
-						<DataTemplate>
-							<ContentView HorizontalOptions="Fill" VerticalOptions="Fill"
+                <dg:DataGrid.HeaderFontSize>
+                    <OnIdiom  x:TypeArguments="x:Double">
+                        <OnIdiom.Tablet>15</OnIdiom.Tablet>
+                        <OnIdiom.Phone>12</OnIdiom.Phone>
+                    </OnIdiom>
+                </dg:DataGrid.HeaderFontSize>
+                <dg:DataGrid.Columns>
+                    <dg:DataGridColumn Title="Logo" PropertyName="Logo" Width="100" SortingEnabled="False">
+                        <dg:DataGridColumn.CellTemplate>
+                            <DataTemplate>
+                                <Image Source="{Binding}" HorizontalOptions="Center" VerticalOptions="Center" Aspect="AspectFit" HeightRequest="60" />
+                            </DataTemplate>
+                        </dg:DataGridColumn.CellTemplate>
+                    </dg:DataGridColumn>
+                    <dg:DataGridColumn Title="Team" PropertyName="Name" Width="2*"/>
+                    <dg:DataGridColumn Title="Win" PropertyName="Win" Width="0.95*"/>
+                    <dg:DataGridColumn Title="Loose" PropertyName="Loose"  Width="1*"/>
+                    <dg:DataGridColumn PropertyName="Home">
+                        <dg:DataGridColumn.FormattedTitle>
+                            <FormattedString>
+                                <Span Text="Home" ForegroundColor="Black" FontSize="13" FontAttributes="Bold"/>
+                                <Span Text=" (win-loose)" ForegroundColor="#333333" FontSize="11" />
+                            </FormattedString>
+                        </dg:DataGridColumn.FormattedTitle>
+                    </dg:DataGridColumn>
+                    <dg:DataGridColumn Title="Percentage" PropertyName="Percentage" StringFormat="{}{0:0.00}" />
+                    <dg:DataGridColumn Title="Streak" PropertyName="Streak" Width="0.7*">
+                        <dg:DataGridColumn.CellTemplate>
+                            <DataTemplate>
+                                <ContentView HorizontalOptions="Fill" VerticalOptions="Fill"
 						 BackgroundColor="{Binding Converter={StaticResource StreakToColorConverter}}">
-								<Label Text="{Binding}" HorizontalOptions="Center" VerticalOptions="Center" TextColor="Black"/>
-							</ContentView>
-						</DataTemplate>
-					</dg:DataGridColumn.CellTemplate>
-				</dg:DataGridColumn>
-			</dg:DataGrid.Columns>
-			<dg:DataGrid.RowsBackgroundColorPalette>
-				<dg:PaletteCollection>
-					<Color>#F2F2F2</Color>
-					<Color>#FFFFFF</Color>
-				</dg:PaletteCollection>
-			</dg:DataGrid.RowsBackgroundColorPalette>
-			<dg:DataGrid.Resources>
-				<ResourceDictionary>
-					<conv:StreakToColorConverter x:Key="StreakToColorConverter"/>
-				</ResourceDictionary>
-			</dg:DataGrid.Resources>
-		</dg:DataGrid>
+                                    <Label Text="{Binding}" HorizontalOptions="Center" VerticalOptions="Center" TextColor="Black"/>
+                                </ContentView>
+                            </DataTemplate>
+                        </dg:DataGridColumn.CellTemplate>
+                    </dg:DataGridColumn>
+                </dg:DataGrid.Columns>
+                <dg:DataGrid.RowsBackgroundColorPalette>
+                    <dg:PaletteCollection>
+                        <Color>#F2F2F2</Color>
+                        <Color>#FFFFFF</Color>
+                    </dg:PaletteCollection>
+                </dg:DataGrid.RowsBackgroundColorPalette>
+                <dg:DataGrid.Resources>
+                    <ResourceDictionary>
+                        <conv:StreakToColorConverter x:Key="StreakToColorConverter"/>
+                    </ResourceDictionary>
+                </dg:DataGrid.Resources>
+            </dg:DataGrid>
+
+            <dg:DataGrid x:Name="ChartTable" Grid.Row="1" ItemsSource="{Binding ChartTable.Rows}" SelectionEnabled="True" SelectedItem="{Binding SelectedRow}"
+                         RowHeight="70" HeaderHeight="50" BorderColor="#CCCCCC" HeaderBackground="#E0E6F8"
+                         PullToRefreshCommand="{Binding RefreshCommand}" IsRefreshing="{Binding IsRefreshing}"
+                         ActiveRowColor="#8899AA">
+                <dg:DataGrid.HeaderFontSize>
+                    <OnIdiom  x:TypeArguments="x:Double">
+                        <OnIdiom.Tablet>15</OnIdiom.Tablet>
+                        <OnIdiom.Phone>12</OnIdiom.Phone>
+                    </OnIdiom>
+                </dg:DataGrid.HeaderFontSize>
+
+                <dg:DataGrid.RowsBackgroundColorPalette>
+                    <dg:PaletteCollection>
+                        <Color>#F2F2F2</Color>
+                        <Color>#FFFFFF</Color>
+                    </dg:PaletteCollection>
+                </dg:DataGrid.RowsBackgroundColorPalette>
+            </dg:DataGrid>
+        </Grid>
 	</ContentView>
 </ContentPage>
 

--- a/DataGridSample/DataGridSample/Views/MainPage.xaml.cs
+++ b/DataGridSample/DataGridSample/Views/MainPage.xaml.cs
@@ -1,18 +1,61 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿using DataGridSample.Models;
+using DataGridSample.ViewModels;
+using DataGridSample.Views.Converters;
 using Xamarin.Forms;
+using Xamarin.Forms.DataGrid;
 
 namespace DataGridSample
 {
-	public partial class MainPage : ContentPage
-	{
-		public MainPage()
-		{
-			InitializeComponent();
-		}
-	}
+    public partial class MainPage : ContentPage
+    {
+        public MainPage()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+            var vm = (MainViewModel) this.BindingContext;
+            var chartTable = vm.ChartTable;
+
+            var dataGridColumns = this.GenerateColumns(chartTable);
+            this.ChartTable.Columns = dataGridColumns;
+        }
+
+        private ColumnCollection GenerateColumns(ChartTable chartTable)
+        {
+            var columns = new ColumnCollection();
+
+            for (var c = 0; c < chartTable.Header.Columns.Length; c++)
+            {
+                var columnIndex = c;
+                var dataGridColumn = new DataGridColumn
+                {
+                    Title = chartTable.Header.Columns[c].Value.ToString(),
+                    SortingEnabled = false,
+                    PropertyName = $"{nameof(ChartTableRow.Columns)}[{columnIndex}].{nameof(ChartTableColumn.Value)}",
+                    Width = new GridLength(1, GridUnitType.Star),
+                    CellTemplate = new DataTemplate(() =>
+                    {
+                        var grid = new Grid();
+                        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                        var label = new Label { FontAttributes = FontAttributes.Bold };
+                        label.SetBinding(Label.TextProperty, new Binding(".", BindingMode.OneWay));
+
+                        grid.Children.Add(label);
+
+                        return new ViewCell
+                        {
+                            View = grid
+                        };
+                    })
+                };
+                columns.Add(dataGridColumn);
+            }
+
+            return columns;
+        }
+    }
 }

--- a/Xamarin.Forms.DataGrid/DataGridViewCell.cs
+++ b/Xamarin.Forms.DataGrid/DataGridViewCell.cs
@@ -93,15 +93,31 @@ namespace Xamarin.Forms.DataGrid
 				View cell;
 
 				if (col.CellTemplate != null)
-                {
-                    cell = new ContentView() { Content = col.CellTemplate.CreateContent() as View };
+				{
+				    View templateView;
+				    var templateContent = col.CellTemplate.CreateContent();
+				    var viewCell = templateContent as ViewCell;
+				    if (viewCell != null)
+				    {
+				        templateView = viewCell.View;
+				    }
+				    else
+				    {
+				        templateView = templateContent as View;
+				        if (templateView == null)
+				        {
+				            throw new Exception($"{nameof(DataGridColumn.CellTemplate)} must either be a {nameof(View)} or a {nameof(ViewCell)} ");
+				        }
+				    }
+
+                    cell = new ContentView { Content = templateView };
                     if (col.PropertyName != null)
                     {
-                        cell.SetBinding(BindableObject.BindingContextProperty, 
+                        cell.SetBinding(BindableObject.BindingContextProperty,
                             new Binding(col.PropertyName, source: RowContext));
                     }
                 }
-				else
+                else
 				{
 					var text = new Label
 					{


### PR DESCRIPTION
Dear Xamarin.Forms.DataGrid community,
I was struggling for hours with data binding problems until I debugged the DataGrid source code and found that DataGridViewCell only supports type "View" as CellTemplate. This PR contains following changes you may want to have a look at:
- Handle ViewCell.View in DataGridViewCell
- Add sample DataGrid with dynamically generated table
