### PR TITLE
Add ItemAppearing and ItemDisappearing events

### DIFF
--- a/Xamarin.Forms.DataGrid/DataGrid.xaml.cs
+++ b/Xamarin.Forms.DataGrid/DataGrid.xaml.cs
@@ -111,6 +111,12 @@ namespace Xamarin.Forms.DataGrid
 					self._listView.RowHeight = (int)n;
 				});
 
+		public static readonly BindableProperty HasUnevenRowsProperty =
+			BindableProperty.Create(nameof(HasUnevenRows), typeof(bool), typeof(DataGrid), false,
+				propertyChanged: (b, o, n) => {
+					var self = b as DataGrid;
+					self._listView.HasUnevenRows = (bool)n;
+		});
 
 		public static readonly BindableProperty HeaderHeightProperty =
 			BindableProperty.Create(nameof(HeaderHeight), typeof(int), typeof(DataGrid), 40,
@@ -348,6 +354,12 @@ namespace Xamarin.Forms.DataGrid
 			set { SetValue(RowHeightProperty, value); }
 		}
 
+		public bool HasUnevenRows
+		{
+			get { return (bool)GetValue(HasUnevenRowsProperty); }
+			set { SetValue(HasUnevenRowsProperty, value); }
+		}
+
 		public int HeaderHeight
 		{
 			get { return (int)GetValue(HeaderHeightProperty); }
@@ -484,6 +496,7 @@ namespace Xamarin.Forms.DataGrid
 			};
 
 			_listView.SetBinding(ListView.RowHeightProperty, new Binding("RowHeight", source: this));
+			_listView.SetBinding(ListView.HasUnevenRowsProperty, new Binding("HasUnevenRows", source: this));
 			Grid.SetRow(_listView, 1);
 			Children.Add(_listView);
 		}

--- a/Xamarin.Forms.DataGrid/DataGrid.xaml.cs
+++ b/Xamarin.Forms.DataGrid/DataGrid.xaml.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms.DataGrid
 	{
 		public event EventHandler Refreshing;
 		public event EventHandler<SelectedItemChangedEventArgs> ItemSelected;
+		public event EventHandler<ItemVisibilityEventArgs> ItemAppearing;
+		public event EventHandler<ItemVisibilityEventArgs> ItemDisappearing;
 
 		#region Bindable properties
 		public static readonly BindableProperty ActiveRowColorProperty =
@@ -471,6 +473,14 @@ namespace Xamarin.Forms.DataGrid
 
 			_listView.Refreshing += (s, e) => {
 				Refreshing?.Invoke(this, e);
+			};
+
+			_listView.ItemAppearing += (s, e) => {
+				ItemAppearing?.Invoke(this, e);
+			};
+
+			_listView.ItemDisappearing += (s, e) => {
+				ItemDisappearing?.Invoke(this, e);
 			};
 
 			_listView.SetBinding(ListView.RowHeightProperty, new Binding("RowHeight", source: this));

--- a/Xamarin.Forms.DataGrid/DataGrid.xaml.cs
+++ b/Xamarin.Forms.DataGrid/DataGrid.xaml.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.DataGrid
 		public event EventHandler<SelectedItemChangedEventArgs> ItemSelected;
 		public event EventHandler<ItemVisibilityEventArgs> ItemAppearing;
 		public event EventHandler<ItemVisibilityEventArgs> ItemDisappearing;
+		public event EventHandler<ScrolledEventArgs> Scrolled;
 
 		#region Bindable properties
 		public static readonly BindableProperty ActiveRowColorProperty =
@@ -493,6 +494,10 @@ namespace Xamarin.Forms.DataGrid
 
 			_listView.ItemDisappearing += (s, e) => {
 				ItemDisappearing?.Invoke(this, e);
+			};
+
+			_listView.Scrolled += (s, e) => {
+				Scrolled?.Invoke(this, e);
 			};
 
 			_listView.SetBinding(ListView.RowHeightProperty, new Binding("RowHeight", source: this));


### PR DESCRIPTION
This library is awesome, but currently was not enough to solve my problem. In my project, I need to dynamically fetch and add more data. I wanted that when user scrolls to the end (or nearly to the end) more data would be fetched and added to the ListView (infinite scroll ListView). An easy way to detect user scrolled to the end is to use ItemAppearing event of ListView, so when last item of ItemSource appears, we know it was scrolled to the end. My idea is create ItemAppearing and ItemDisappearing events in DataGrid which is going to be invoked from ListView events ItemAppearing  and ItemDisappearing.